### PR TITLE
Fix setting compiler flags in multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,9 @@ TARGET_INCLUDE_DIRECTORIES(Wisteria PUBLIC ${wxWidgets_INCLUDE_DIRS})
 
 # Set warnings and optimizations (will propagate to the demo project also)
 IF(MSVC)
-    # /Zc:__cplusplus tells MSVC to set the C++ versito what we are
+    # /Zc:__cplusplus tells MSVC to set the C++ version what we are
     # actually compiling as. The default behavior in MSVC is to say that the
-    # C++ version is 98 always (for compatability reasons).
+    # C++ version is 98 always (for compatibility reasons).
 
     # /wd6211 turns off C6211 warning: leaking memory due to an exception.
     # wxWidgets uses heap-based objects for most everything, and MVSC complains

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,24 +78,16 @@ TARGET_INCLUDE_DIRECTORIES(Wisteria PUBLIC ${wxWidgets_INCLUDE_DIRS})
 
 # Set warnings and optimizations (will propagate to the demo project also)
 IF(MSVC)
-    IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        # /Zc:__cplusplus tells MSVC to set the C++ version to what we are
-        # actually compiling as. The default behavior in MSVC is to say that the
-        # C++ version is 98 always (for compatability reasons).
+    # /Zc:__cplusplus tells MSVC to set the C++ versito what we are
+    # actually compiling as. The default behavior in MSVC is to say that the
+    # C++ version is 98 always (for compatability reasons).
 
-        # Turns off C6211 warning: leaking memory due to an exception.
-        # wxWidgets uses heap-based objects for most everything, and MVSC complains
-        # about not wrapping all of this logic in try blocks.
-        TARGET_COMPILE_OPTIONS(Wisteria PUBLIC /Zc:__cplusplus /W3 /WX /Od /wd6211)
-    ELSE()
-        TARGET_COMPILE_OPTIONS(Wisteria PUBLIC /Zc:__cplusplus /W3 /WX /O2 /wd6211)
-    ENDIF()
+    # /wd6211 turns off C6211 warning: leaking memory due to an exception.
+    # wxWidgets uses heap-based objects for most everything, and MVSC complains
+    # about not wrapping all of this logic in try blocks.
+    TARGET_COMPILE_OPTIONS(Wisteria PUBLIC /Zc:__cplusplus /W3 /WX /wd6211 $<$<CONFIG:Debug>:/Od> $<$<CONFIG:Release>:/O2>)
 ELSE()
-    IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        TARGET_COMPILE_OPTIONS(Wisteria PUBLIC -Wall -Wextra -Wpedantic -Og)
-    ELSE()
-        TARGET_COMPILE_OPTIONS(Wisteria PUBLIC -Wall -Wextra -Wpedantic -O2)
-    ENDIF()
+    TARGET_COMPILE_OPTIONS(Wisteria PUBLIC -Wall -Wextra -Wpedantic $<$<CONFIG:Debug>:-Og> $<$<CONFIG:Release>:-O2>)
 ENDIF()
 
 # Build the demo


### PR DESCRIPTION
This is an attempt to fix Issue #2. TBH, I am not a fan of forcing compiler options like this, but I followed the suit.

Using `$<$<NOT:$<CONFIG:Debug>X>` instead of `$<$<CONFIG:Release>X>` would probably be more to the letter of the original code but IMO my solution is more to its spirit.

It appears there could be more improvements done in the CMakeLists.txt: For example turning on multiprocessor compilation for MSVS generators, which improves the build times significantly. I did not dare to make these yet.

**EDIT**
I somehow managed to make a typo in the comment which I fixed in another commit (I also fixed the typo that was already there). So, were the PR is going to be accepted, the two commits would have to be squashed.