### PR TITLE
Remove [[nodiscard]] attribute from methods returning void

### DIFF
--- a/src/base/reportbuilder.h
+++ b/src/base/reportbuilder.h
@@ -233,7 +233,7 @@ namespace Wisteria
         /** @brief Loads additional transformation features and applies them to a dataset.
             @param dsNode The datasouce node that the dataset was loaded from.
             @param[in,out] dataset The dataset apply the transformations to.*/
-        [[nodiscard]] void LoadDatasetTransformations(
+        void LoadDatasetTransformations(
             const wxSimpleJSON::Ptr_t& dsNode,
             std::shared_ptr<Data::Dataset>& dataset);
 

--- a/src/graphs/piechart.h
+++ b/src/graphs/piechart.h
@@ -579,7 +579,7 @@ namespace Wisteria::Graphs
                 LineStyle::Arrows will look odd in this situation, so LineStyle::Lines will
                 be explicitily used.
              @sa SetLabelPlacement().*/
-        [[nodiscard]] void SetInnerPieConnectionLineStyle(const LineStyle lStyle) noexcept
+        void SetInnerPieConnectionLineStyle(const LineStyle lStyle) noexcept
             { m_connectionLineStyle = lStyle; }
 
         /// @returns What the labels on the middle points along the inner ring are displaying.


### PR DESCRIPTION
Without this change, the build fails with MSVC (2017), since Wisteria CMakefile tells the compiler to treat warnings as errors:
```
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1301): error C2220: warning treated as error - no 'object' file generated
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1301): warning C4834: discarding return value of function with 'nodiscard' attribute
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1301): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1317): warning C4834: discarding return value of function with 'nodiscard' attribute
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1317): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1450): warning C4834: discarding return value of function with 'nodiscard' attribute
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1450): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1672): warning C4834: discarding return value of function with 'nodiscard' attribute
1>D:\dev\Desktop\Lib\Wisteria-Dataviz-GIT\src\base\reportbuilder.cpp(1672): note: to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
1>Done building project "Wisteria.vcxproj" -- FAILED.
```

Other compilers could warn when the function is just declared, not even called.

**EDIT** These warnings are not present in MSVS 2022 (v17.3.3). With GCC 12.2, the attribute warning is there and GCC also warns that attribute usage is incorrect in method declaration (between `static` and return type). There are also many other GCC warnings and not all of them are -Wreorder.